### PR TITLE
tests: add @covers tags to PHPUnit tests

### DIFF
--- a/Tests/Functional/BundleInitializationTest.php
+++ b/Tests/Functional/BundleInitializationTest.php
@@ -23,6 +23,20 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 
+/**
+ * @covers \Dziki\MonologSentryBundle\MonologSentryBundle
+ * @covers \Dziki\MonologSentryBundle\DependencyInjection\Configuration
+ * @covers \Dziki\MonologSentryBundle\DependencyInjection\MonologSentryExtension
+ *
+ * @uses \Dziki\MonologSentryBundle\Handler\Raven
+ * @uses \Dziki\MonologSentryBundle\DependencyInjection\Compiler\MonologHandlerOverridePass
+ * @uses \Dziki\MonologSentryBundle\Processor\TagAppending
+ * @uses \Dziki\MonologSentryBundle\UserAgent\PhpUserAgentParser
+ * @uses \Dziki\MonologSentryBundle\UserAgent\UserAgent
+ * @uses \Dziki\MonologSentryBundle\SubscribedProcessor\BrowserDataAppending
+ * @uses \Dziki\MonologSentryBundle\SubscribedProcessor\UserDataAppending
+ * @uses \Dziki\MonologSentryBundle\UserAgent\CachedParser
+ */
 class BundleInitializationTest extends BaseBundleTestCase
 {
     /**

--- a/Tests/Functional/MonologSentryExtensionTest.php
+++ b/Tests/Functional/MonologSentryExtensionTest.php
@@ -7,11 +7,13 @@ namespace Dziki\MonologSentryBundle\Tests\Functional;
 use Dziki\MonologSentryBundle\DependencyInjection\MonologSentryExtension;
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
 
+
 class MonologSentryExtensionTest extends AbstractExtensionTestCase
 {
     /**
      * @test
      * @covers \Dziki\MonologSentryBundle\DependencyInjection\MonologSentryExtension::load
+     * @uses \Dziki\MonologSentryBundle\DependencyInjection\Configuration
      */
     public function checkIfServicesDefinedAccordingToConfig(): void
     {

--- a/Tests/Unit/DependencyInjection/Compiler/MonologHandlerOverridePassTest.php
+++ b/Tests/Unit/DependencyInjection/Compiler/MonologHandlerOverridePassTest.php
@@ -11,6 +11,9 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 
+/**
+ * @covers \Dziki\MonologSentryBundle\DependencyInjection\Compiler\MonologHandlerOverridePass
+ */
 class MonologHandlerOverridePassTest extends TestCase
 {
     /**

--- a/Tests/Unit/Handler/RavenTest.php
+++ b/Tests/Unit/Handler/RavenTest.php
@@ -11,6 +11,9 @@ use Monolog\Logger;
 use PHPUnit\Framework\TestCase;
 use Raven_Client;
 
+/**
+ * @covers \Dziki\MonologSentryBundle\Handler\Raven
+ */
 class RavenTest extends TestCase
 {
     public function setUp()

--- a/Tests/Unit/Processor/TagAppendingTest.php
+++ b/Tests/Unit/Processor/TagAppendingTest.php
@@ -7,6 +7,9 @@ namespace Dziki\MonologSentryBundle\Tests\Unit\Processor;
 use Dziki\MonologSentryBundle\Processor\TagAppending;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @covers \Dziki\MonologSentryBundle\Processor\TagAppending
+ */
 class TagAppendingTest extends TestCase
 {
     /**

--- a/Tests/Unit/SubscribedProcessor/BrowserDataAppendingTest.php
+++ b/Tests/Unit/SubscribedProcessor/BrowserDataAppendingTest.php
@@ -14,6 +14,11 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
+/**
+ * @covers \Dziki\MonologSentryBundle\SubscribedProcessor\BrowserDataAppending
+ *
+ * @uses \Dziki\MonologSentryBundle\UserAgent\UserAgent
+ */
 class BrowserDataAppendingTest extends TestCase
 {
     /**

--- a/Tests/Unit/SubscribedProcessor/UserDataAppendingTest.php
+++ b/Tests/Unit/SubscribedProcessor/UserDataAppendingTest.php
@@ -12,6 +12,9 @@ use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInt
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 
+/**
+ * @covers \Dziki\MonologSentryBundle\SubscribedProcessor\UserDataAppending
+ */
 class UserDataAppendingTest extends TestCase
 {
     /**

--- a/Tests/Unit/UserAgent/AbstractParserTest.php
+++ b/Tests/Unit/UserAgent/AbstractParserTest.php
@@ -8,6 +8,9 @@ use Dziki\MonologSentryBundle\UserAgent\ParserInterface;
 use Dziki\MonologSentryBundle\UserAgent\UserAgent;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @covers \Dziki\MonologSentryBundle\Tests\Unit\UserAgent\AbstractParser
+ */
 abstract class AbstractParserTest extends TestCase
 {
     /** @var ParserInterface */

--- a/Tests/Unit/UserAgent/CachedParserTest.php
+++ b/Tests/Unit/UserAgent/CachedParserTest.php
@@ -10,6 +10,11 @@ use Dziki\MonologSentryBundle\UserAgent\UserAgent;
 use PHPUnit\Framework\TestCase;
 use Psr\SimpleCache\CacheInterface;
 
+/**
+ * @covers \Dziki\MonologSentryBundle\UserAgent\CachedParser
+ *
+ * @uses \Dziki\MonologSentryBundle\UserAgent\UserAgent
+ */
 class CachedParserTest extends TestCase
 {
     /**

--- a/Tests/Unit/UserAgent/NativeParserTest.php
+++ b/Tests/Unit/UserAgent/NativeParserTest.php
@@ -7,6 +7,11 @@ namespace Dziki\MonologSentryBundle\Tests\Unit\UserAgent;
 use Dziki\MonologSentryBundle\UserAgent\NativeParser;
 use Dziki\MonologSentryBundle\UserAgent\UserAgent;
 
+/**
+ * @covers \Dziki\MonologSentryBundle\UserAgent\NativeParser
+ *
+ * @uses \Dziki\MonologSentryBundle\UserAgent\UserAgent
+ */
 class NativeParserTest extends AbstractParserTest
 {
     public function validUserAgentsDataProvider(): array

--- a/Tests/Unit/UserAgent/PhpUserAgentParserTest.php
+++ b/Tests/Unit/UserAgent/PhpUserAgentParserTest.php
@@ -7,6 +7,11 @@ namespace Dziki\MonologSentryBundle\Tests\Unit\UserAgent;
 use Dziki\MonologSentryBundle\UserAgent\PhpUserAgentParser;
 use Dziki\MonologSentryBundle\UserAgent\UserAgent;
 
+/**
+ * @covers \Dziki\MonologSentryBundle\UserAgent\PhpUserAgentParser
+ *
+ * @uses \Dziki\MonologSentryBundle\UserAgent\UserAgent
+ */
 class PhpUserAgentParserTest extends AbstractParserTest
 {
     public function validUserAgentsDataProvider(): array

--- a/Tests/Unit/UserAgent/UserAgentTest.php
+++ b/Tests/Unit/UserAgent/UserAgentTest.php
@@ -7,6 +7,9 @@ namespace Dziki\MonologSentryBundle\Tests\Unit\UserAgent;
 use Dziki\MonologSentryBundle\UserAgent\UserAgent;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @covers \Dziki\MonologSentryBundle\UserAgent\UserAgent
+ */
 class UserAgentTest extends TestCase
 {
     /**

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<phpunit colors="true" bootstrap="vendor/autoload.php">
+<phpunit colors="true" bootstrap="vendor/autoload.php"
+         forceCoversAnnotation="true"
+         beStrictAboutCoversAnnotation="true"
+         beStrictAboutOutputDuringTests="true"
+         beStrictAboutResourceUsageDuringSmallTests="true"
+         beStrictAboutTodoAnnotatedTests="true"
+         failOnWarning="true"
+         failOnRisky="true"
+>
     <testsuites>
         <testsuite name="MonologSentryBundle for the Symfony Framework">
             <directory>./Tests</directory>


### PR DESCRIPTION
Adding `@covers` as `@uses` to your tests significantly reduces the chance of false coverage.

http://edorian.github.io/2011-11-04-An-introduction-to-phpunits-covers-annotation/